### PR TITLE
Show Rails env in prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Example `config/initializers/jazz_hands.rb`:
 if defined?(JazzHands)
   JazzHands.colored_prompt = false
   JazzHands.enable_syntax_highlighting_as_you_type!
+  JazzHands.rails_env_in_prompt = true
 end
 ```
 
@@ -68,6 +69,10 @@ Note: `Pry.color = false` trumps this setting and disables all console coloring.
 Separator string between the application name and line input. Defaults to `»`
 for GNU readline or libedit. Defaults to `>` for `rb-readline` which fails on
 mixed encodings.
+
+### `rails_env_in_prompt`
+
+Set to `true` to show the Rails environment in the prompt. Default: `false`.
 
 ### Syntax highlighting
 

--- a/lib/jazz_hands.rb
+++ b/lib/jazz_hands.rb
@@ -28,6 +28,13 @@ module JazzHands
   mattr_accessor :prompt_separator
   self.prompt_separator = defined?(RbReadline) ? '>' : "\u00BB"
 
+  # Include the Rails.env in the prompt?
+  #
+  # Default: false
+  #
+  mattr_accessor :rails_env_in_prompt
+  self.rails_env_in_prompt = false
+
 
   class << self
     # Enable syntax highlighting as you type in the Rails console via coolline and

--- a/lib/jazz_hands/railtie.rb
+++ b/lib/jazz_hands/railtie.rb
@@ -40,6 +40,7 @@ module JazzHands
         bold = ->(text) { color[] ? "\001\e[1m\002#{text}\001\e[0m\002"    : text.to_s }
 
         separator = -> { red.(JazzHands.prompt_separator) }
+        rails_env = -> { JazzHands.rails_env_in_prompt ? "(#{Rails.env})" : nil }
         name = app.class.parent_name.underscore
         colored_name = -> { blue.(name) }
 
@@ -55,7 +56,7 @@ module JazzHands
 
         Pry.config.prompt = [
           ->(object, level, pry) do      # Main prompt
-            "#{line.(pry)}#{colored_name.()}#{target_string.(object, level)} #{separator.()}  "
+            "#{line.(pry)}#{colored_name.()}#{rails_env.()}#{target_string.(object, level)} #{separator.()}  "
           end,
           ->(object, level, pry) do      # Wait prompt in multiline input
             spaces = ' ' * (


### PR DESCRIPTION
Hi there! Our team finds it very useful to show the Rails.env in the prompt since we use jazz_hands on all our environments. Let me know if you find this patch useful or if any modifications need to be made.
