### PR TITLE
Support for ruby 2.1.2

### DIFF
--- a/jazz_hands.gemspec
+++ b/jazz_hands.gemspec
@@ -18,14 +18,14 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   # Dependencies
-  gem.required_ruby_version = '>= 1.9.2'
+  gem.required_ruby_version = '>= 2.0.0'
   gem.add_runtime_dependency 'pry', '~> 0.9.12'
   gem.add_runtime_dependency 'pry-rails', '~> 0.3.2'
   gem.add_runtime_dependency 'pry-doc', '~> 0.4.6'
   gem.add_runtime_dependency 'pry-git', '~> 0.2.3'
   gem.add_runtime_dependency 'pry-stack_explorer', '~> 0.4.9'
   gem.add_runtime_dependency 'pry-remote', '>= 0.1.7'
-  gem.add_runtime_dependency 'pry-debugger', '~> 0.2.2'
+  gem.add_runtime_dependency 'pry-byebug', '>= 1.3.0'
   gem.add_runtime_dependency 'hirb', '~> 0.7.1'
   gem.add_runtime_dependency 'coolline', '>= 0.4.2'
   gem.add_runtime_dependency 'awesome_print', '~> 1.2'

--- a/lib/jazz_hands/railtie.rb
+++ b/lib/jazz_hands/railtie.rb
@@ -6,7 +6,7 @@ require 'pry-remote'
 require 'pry-stack_explorer'
 require 'awesome_print'
 require 'jazz_hands/hirb_ext'
-require 'pry-debugger'
+require 'pry-byebug'
 
 
 module JazzHands


### PR DESCRIPTION
Installation of jazz_hands is currently failing on ruby 2.1.2 because of it's dependencies - particularly `pry-debugger` which is currently broken for 2.1.2, because of it's dependency `debugger`. Even though `debugger` works with rubies 2.0 up to 2.1.1, it's not supposed to (more info here: https://github.com/cldwalker/debugger/issues/125#issuecomment-43353446 and here https://github.com/cldwalker/debugger/issues/125#issuecomment-43358018). As ruby 2 is used more and more frequently this change might be beneficial.
