### PR TITLE
Using byebug when ruby > 2

### DIFF
--- a/jazz_hands.gemspec
+++ b/jazz_hands.gemspec
@@ -25,7 +25,13 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pry-git', '~> 0.2.3'
   gem.add_runtime_dependency 'pry-stack_explorer', '~> 0.4.9'
   gem.add_runtime_dependency 'pry-remote', '>= 0.1.7'
-  gem.add_runtime_dependency 'pry-debugger', '~> 0.2.2'
+  
+  if RUBY_VERSION > '2'
+    gem.add_runtime_dependency 'pry-byebug', '> 1.3', '< 2'
+  else
+    gem.add_runtime_dependency 'pry-debugger', '~> 0.2.2'
+  end
+  
   gem.add_runtime_dependency 'hirb', '~> 0.7.1'
   gem.add_runtime_dependency 'coolline', '>= 0.4.2'
   gem.add_runtime_dependency 'awesome_print', '~> 1.2'

--- a/lib/jazz_hands/railtie.rb
+++ b/lib/jazz_hands/railtie.rb
@@ -6,8 +6,11 @@ require 'pry-remote'
 require 'pry-stack_explorer'
 require 'awesome_print'
 require 'jazz_hands/hirb_ext'
-require 'pry-debugger'
-
+if RUBY_VERSION > '2'
+  require 'pry-byebug'
+else
+  require 'pry-debugger'
+end
 
 module JazzHands
   class Railtie < Rails::Railtie


### PR DESCRIPTION
Hello everybody,

the gem 'byebug' is the replacement for gem 'debugger' on ruby > 2.
i know that are a branch that enable use another debugger,
but the current version **does not** install on ruby 2.1.2.
that way, we keep the compatibility and allow to install on newer versions
