### PR TITLE
Use newer version of pry

### DIFF
--- a/jazz_hands.gemspec
+++ b/jazz_hands.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.9.2'
-  gem.add_runtime_dependency 'pry', '~> 0.9.12'
+  gem.add_runtime_dependency 'pry', '~> 0.10.0'
   gem.add_runtime_dependency 'pry-rails', '~> 0.3.2'
   gem.add_runtime_dependency 'pry-doc', '~> 0.4.6'
   gem.add_runtime_dependency 'pry-git', '~> 0.2.3'

--- a/jazz_hands.gemspec
+++ b/jazz_hands.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.9.2'
-  gem.add_runtime_dependency 'pry', '~> 0.10.0'
+  gem.add_runtime_dependency 'pry', '~> 0.10.1'
   gem.add_runtime_dependency 'pry-rails', '~> 0.3.2'
   gem.add_runtime_dependency 'pry-doc', '~> 0.4.6'
   gem.add_runtime_dependency 'pry-git', '~> 0.2.3'

--- a/jazz_hands.gemspec
+++ b/jazz_hands.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pry-stack_explorer', '~> 0.4.9'
   gem.add_runtime_dependency 'pry-remote', '>= 0.1.7'
   gem.add_runtime_dependency 'hirb', '~> 0.7.1'
-  gem.add_runtime_dependency 'coolline', '>= 0.4.2'
+  gem.add_runtime_dependency 'pry-coolline', '>= 0.2.4'
   gem.add_runtime_dependency 'awesome_print', '~> 1.2'
   gem.add_runtime_dependency 'railties', '>= 3.0', '< 5.0'
 end

--- a/lib/jazz_hands/railtie.rb
+++ b/lib/jazz_hands/railtie.rb
@@ -17,10 +17,10 @@ module JazzHands
 
         # Use awesome_print for output, but keep pry's pager. If Hirb is
         # enabled, try printing with it first.
-        Pry.config.print = ->(output, value) do
+        Pry.config.print = ->(output, value, _pry_) do
           return if JazzHands._hirb_output && Hirb::View.view_or_page_output(value)
           pretty = value.ai(indent: 2)
-          Pry::Helpers::BaseHelpers.stagger_output("=> #{pretty}", output)
+          _pry_.pager.page("=> #{pretty}")
         end
 
         # Friendlier prompt - line number, app name, nesting levels look like


### PR DESCRIPTION
This lets me use jazz_hands in ruby 2.1 with the latest pry.
