### PR TITLE
Update README to reflect better option for specifying options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ X) will work but is not recommended.
 
 ## Options
 
-Change the following options by creating an initializer in your Rails project
-Example `config/initializers/jazz_hands.rb`:
+Set options by editing `~/.pryrc`:
 
 ```ruby
 if defined?(JazzHands)


### PR DESCRIPTION
A better location to specify options is `~/.pryrc` as Rails initializers apply to all developers should they be committed.
