### PR TITLE
Update pry to 0.10.4

### DIFF
--- a/jazz_hands.gemspec
+++ b/jazz_hands.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.9.2'
-  gem.add_runtime_dependency 'pry', '~> 0.9.12'
+  gem.add_runtime_dependency 'pry', '~> 0.10.4'
   gem.add_runtime_dependency 'pry-rails', '~> 0.3.2'
   gem.add_runtime_dependency 'pry-doc', '~> 0.4.6'
   gem.add_runtime_dependency 'pry-git', '~> 0.2.3'


### PR DESCRIPTION
pry-rails v0.3.5 has a bug that is resolved in v0.3.6
pry-rails v0.3.6 depends on pry 0.10.4
Updating to get the fix for pry-rails